### PR TITLE
remove opencl from gpu.go

### DIFF
--- a/gpu.go
+++ b/gpu.go
@@ -3,15 +3,13 @@
 
 package nanopow
 
-import "github.com/bbedward/go-opencl/opencl"
-
 type noneGPUWorker struct{}
 
-func NewWorkerGPU(device opencl.Device) (*noneGPUWorker, error) {
-	return NewWorkerGPUThread(0, device)
+func NewWorkerGPU(_ interface{}) (*noneGPUWorker, error) {
+	return NewWorkerGPUThread(0, nil)
 }
 
-func NewWorkerGPUThread(_ uint64, _ opencl.Device) (*noneGPUWorker, error) {
+func NewWorkerGPUThread(_ uint64, _ interface{}) (*noneGPUWorker, error) {
 	return nil, ErrNotSupported
 }
 
@@ -19,6 +17,6 @@ func (w *noneGPUWorker) GenerateWork(ctx *Context, root []byte, difficulty uint6
 	return ErrNotSupported
 }
 
-func GetDevice() (dv opencl.Device, err error) {
-	return opencl.Device{}, ErrNotSupported
+func GetDevice() (interface{}, error) {
+	return nil, ErrNotSupported
 }


### PR DESCRIPTION
It's not necessary to import `github.com/bbedward/go-opencl/opencl` in `gpu.go` and it was causing compiler errors in some environments without OpenCL.